### PR TITLE
fix(deps): update rexml to 3.4.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source "https://rubygems.org"
 gem "github-pages", group: :jekyll_plugins
 
 # Security updates for vulnerable dependencies
-gem "rexml", "~> 3.3.9"
+gem "rexml", "~> 3.4.4"
 gem "nokogiri", "~> 1.18.3"
 gem "uri", "~> 0.13.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,7 +274,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.9)
+    rexml (3.4.4)
     rouge (3.30.0)
     rubyzip (2.4.1)
     safe_yaml (1.0.5)
@@ -316,7 +316,7 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   nokogiri (~> 1.18.3)
-  rexml (~> 3.3.9)
+  rexml (~> 3.4.4)
   uri (~> 0.13.2)
 
 BUNDLED WITH


### PR DESCRIPTION
## Summary
- Update rexml from 3.3.9 to 3.4.4 to resolve security vulnerability
- Resolves Dependabot alert for rexml

## Test plan
- [x] Bundle update succeeds
- [ ] Jekyll build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)